### PR TITLE
Feat: Add xAI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ This fork of Codex supports multiple AI providers:
 - gemini
 - openrouter
 - ollama
+- xai
 
 To use a different provider, set the `provider` key in your config file:
 
@@ -316,6 +317,7 @@ Here's a list of all the providers and their default models:
 | gemini     | GOOGLE_GENERATIVE_AI_API_KEY  | gemini-2.5-pro-preview-03-25 | gemini-2.0-flash           |
 | openrouter | OPENROUTER_API_KEY            | openai/o4-mini               | openai/o3                  |
 | ollama     | Not required                  | User must specify            | User must specify          |
+| xai        | XAI_API_KEY                   | grok-3-mini-beta             | grok-3-beta                |
 
 #### When using an alternative provider, make sure you have the correct environment variables set.
 

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -53,7 +53,7 @@ const cli = meow(
 
   Options
     -h, --help                 Show usage and exit
-    -m  --provider <provider>  Provider to use for completions (default: openai, options: openai, gemini, openrouter)
+    -m  --provider <provider>  Provider to use for completions (default: openai, options: openai, gemini, openrouter, ollama, xai)
     -m, --model <model>        Model to use for completions (default: o4-mini)
     -i, --image <path>         Path(s) to image files to include as input
     -v, --view <rollout>       Inspect a previously saved rollout instead of starting a session

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -42,6 +42,8 @@ if (!process.env["OPENAI_API_KEY"]) {
     DEFAULT_PROVIDER = "gemini";
   } else if (process.env["OPENROUTER_API_KEY"]) {
     DEFAULT_PROVIDER = "openrouter";
+  } else if (process.env["XAI_API_KEY"]) {
+    DEFAULT_PROVIDER = "xai";
   }
 }
 
@@ -71,6 +73,13 @@ function getAPIKeyForProviderOrExit(provider: string): string {
     case "ollama":
       // Ollama doesn't require an API key but the openai client requires one
       return "ollama";
+    case "xai":
+      if (process.env["XAI_API_KEY"]) {
+        return process.env["XAI_API_KEY"];
+      }
+      reportMissingAPIKeyForProvider(provider);
+      process.exit(1);
+      break;
     default:
       reportMissingAPIKeyForProvider("");
       process.exit(1);
@@ -87,6 +96,8 @@ function baseURLForProvider(provider: string): string {
       return "https://generativelanguage.googleapis.com/v1beta/openai/";
     case "openrouter":
       return "https://openrouter.ai/api/v1";
+    case "xai":
+      return "https://api.x.ai/v1";
     default:
       // TODO throw?
       return "";
@@ -112,6 +123,11 @@ function defaultModelsForProvider(provider: string): {
       return {
         agentic: "openai/o4-mini",
         fullContext: "openai/o3",
+      };
+    case "xai":
+      return {
+        agentic: "grok-3-mini-beta",
+        fullContext: "grok-3-beta",
       };
     default:
       return {

--- a/codex-cli/src/utils/model-utils.ts
+++ b/codex-cli/src/utils/model-utils.ts
@@ -115,6 +115,8 @@ export function reportMissingAPIKeyForProvider(provider: string): void {
             return `- ${chalk.bold(
               "GOOGLE_GENERATIVE_AI_API_KEY",
             )} for Google Gemini models\n`;
+          case "xai":
+            return `- ${chalk.bold("XAI_API_KEY")} for xAI models\n`;
           default:
             return (
               [
@@ -123,6 +125,7 @@ export function reportMissingAPIKeyForProvider(provider: string): void {
                 `- ${chalk.bold(
                   "GOOGLE_GENERATIVE_AI_API_KEY",
                 )} for Google Gemini models`,
+                `- ${chalk.bold("XAI_API_KEY")} for xAI models`,
               ].join("\n") + "\n"
             );
         }
@@ -141,6 +144,10 @@ export function reportMissingAPIKeyForProvider(provider: string): void {
           case "gemini":
             return `You can create a Google Generative AI key here: ${chalk.bold(
               chalk.underline("https://aistudio.google.com/apikey"),
+            )}\n`;
+          case "xai":
+            return `You can create an xAI key here: ${chalk.bold(
+              chalk.underline("https://console.x.ai/team/default/api-keys"),
             )}\n`;
           default:
             return "";


### PR DESCRIPTION
Had some xAI credits and didn't want to pay the Open Router 5% fee, so I vibe coded the xAI integration.

I ran `npm test && npm run lint && npm run typecheck` and also tested this change by running `node ./dist/cli.js`, setting `XAI_API_KEY` and setting `~/.codex/config.json` to

```json
{
    "provider": "xai"
}
```

Upon trying the xAI API a bit more I noticed that it always tried to include line numbers in the `apply_patch` command generated by https://github.com/jonnylangefeld/open-codex/blob/fc1e45636edbda95a240c7d6bec7e75b2709cd19/codex-cli/src/utils/agent/agent-loop.ts#L1154 and used by https://github.com/jonnylangefeld/open-codex/blob/fc1e45636edbda95a240c7d6bec7e75b2709cd19/codex-cli/src/utils/agent/exec.ts#L57

The added line numbers failed the exec command. The default OpenAI completion response usually didn't include line numbers. I fixed this simply by adding this to `~/.codex/instructions.md`.

```markdown
- when generating the `apply_patch` command content, do not include line numbers under any circumstance. Simply separate the different patch sections with `@@`
```